### PR TITLE
DeltaChat Bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ Awesome list of Cuban open source projects. Just to know what is being openly de
 - [Cuba-Weather_bot](https://github.com/correaleyval/Cuba-Weather_bot) consults weather info from www.redcuba.cu using [cuba-weather](https://github.com/daxslab/cuba-weather).
 - [web_podcast](https://github.com/rocana95/web-podcast) bot serving ElEnjambre podcasts via Telegram.
 
+## Deltachat Bots
+
+- [simplebot](https://github.com/adbenitez/simplebot) [WIP] A pluginable Delta Chat bot written in Python3.
+
 ## Tutorials & Challenges
 
 - [PyCalc](https://github.com/lpozo/python-calculator): PyCalc is a sample calculator implemented using Python 3. The GUI is built using [PyQt5](https://www.riverbankcomputing.com/static/Docs/PyQt5/introduction.html), [Tkinter](https://docs.python.org/3/library/tkinter.html), [PySide2](https://wiki.qt.io/Qt_for_Python), and [wxPython](http://wxpython.org/) to show the flexibility of the [Model-View-Controller (MVC) pattern](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller).


### PR DESCRIPTION
Simplebot es un bot para Deltachat (https://delta.chat). En el repositorio tambien se encuentran implementados varios plugins que permiten acceder a varios servicios utiles como navegación web utilizando el email, traducción, obtener el estado del tiempo, unirse a varios grupos gestionados por el bot a traves de deltachat o crear tus propios grupos, etc. Proyecto que viene como anillo al dedo a los cubanos que se les dificulta comprar paquetes de Internet y solo pueden acceder a la bolsa nauta.

https://tecnolikecuba.com/bot-super-util-para-delta-chat/

http://adbenitez.cubava.cu/